### PR TITLE
Allow Service Start on Connect Failure AZZ-764

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Properties
 -   **room**: Socket.IO room.
 -   **content**: Content to send to room. Should be json encoded.
 -   **listen**: whether or not the block should listen to messages from the SocketIo room.
+-   **start_without_server**: Allow the service in which this block is running to start even if it is unable to connect to the client initially. The block will then try to reconnect given the retry strategy.
 
 
 Dependencies
@@ -25,7 +26,7 @@ Dependencies
 
 Commands
 ----------------
-None
+-   **reconnect_client**: reconnect to a disconnected client. 
 
 Input
 -------

--- a/socketio_block.py
+++ b/socketio_block.py
@@ -59,6 +59,7 @@ class SocketIO(Retry, Block):
         self._socket_url_protocol = "http"
         self._socket_url_base = ""
         self._stopping = False
+        self._disconnect_thread = None
 
     def configure(self, context):
         super().configure(context)
@@ -76,7 +77,7 @@ class SocketIO(Retry, Block):
                 self.logger.info('Could not connect to web socket. Service '
                                  'will be started and this block will attempt '
                                  'to reconnect using given retry strategy.')
-                self.disconnect_thread = spawn(self.handle_disconnect)
+                self._disconnect_thread = spawn(self.handle_disconnect)
             else:
                 raise
 
@@ -87,8 +88,8 @@ class SocketIO(Retry, Block):
         self._stopping = True
         self.logger.debug("Shutting down socket.io client")
 
-        if self.disconnect_thread:
-            self.disconnect_thread.join()
+        if self._disconnect_thread:
+            self._disconnect_thread.join()
 
         self._close_client()
         super().stop()

--- a/socketio_block.py
+++ b/socketio_block.py
@@ -1,22 +1,19 @@
-import requests
 import json
 import re
 from threading import Event, BoundedSemaphore
+import requests
 
-from nio.command import command
-
-from .client.client import SocketIOWebSocketClient
+from nio.block.base import Block
 from nio.block.mixins.retry.retry import Retry
-from nio import Block, Signal
-from nio.util.discovery import discoverable
 from nio.properties import BoolProperty, IntProperty, StringProperty, \
     Property, VersionProperty, TimeDeltaProperty
+from nio.signal.base import Signal
 from nio.signal.status import BlockStatusSignal
 from nio.util.runner import RunnerStatus
 
+from .client.client import SocketIOWebSocketClient
 
-@discoverable
-@command('reconnect_client')
+
 class SocketIO(Retry, Block):
 
     """ A block for communicating with a socket.io server.

--- a/socketio_block.py
+++ b/socketio_block.py
@@ -5,6 +5,7 @@ import requests
 
 from nio.block.base import Block
 from nio.block.mixins.retry.retry import Retry
+from nio.command import command
 from nio.properties import BoolProperty, IntProperty, StringProperty, \
     Property, VersionProperty, TimeDeltaProperty
 from nio.signal.base import Signal
@@ -15,6 +16,7 @@ from nio.util.threading import spawn
 from .client.client import SocketIOWebSocketClient
 
 
+@command('reconnect_client')
 class SocketIO(Retry, Block):
 
     """ A block for communicating with a socket.io server.


### PR DESCRIPTION
This puts in a configurable behavior to allow a service containing a socketio block to start even if it fails to reconnect initially. It will attempt to reconnect based on its retry strategy in this case. Does not change the default socketio block behavior. 